### PR TITLE
Update calls to deprecated and removed functions

### DIFF
--- a/SkinStatsForSharks.php
+++ b/SkinStatsForSharks.php
@@ -24,6 +24,7 @@ class SkinStatsForSharks extends SkinTemplate {
 		$this->canonicalURL = $out->getContext()->getTitle()->getCanonicalURL();
 
 		$out->addMeta('viewport', 'width=device-width, initial-scale=1');
+		$this->setupStatsForSharksCSS( $out );
 
 		//print_r($out);
 
@@ -484,9 +485,7 @@ class SkinStatsForSharks extends SkinTemplate {
 	 * Loads skin and user CSS files.
 	 * @param OutputPage $out
 	 */
-	function setupSkinUserCss(OutputPage $out) {
-		parent::setupSkinUserCss($out);
-
+	function setupStatsForSharksCSS(OutputPage $out) {
 		$styles = ['mediawiki.skinning.interface', 'skins.statsforsharks.styles'];
 		$out->addModuleStyles($styles);
 	}

--- a/StatsForSharksTemplate.php
+++ b/StatsForSharksTemplate.php
@@ -239,7 +239,7 @@ class StatsForSharksTemplate extends BaseTemplate {
 								<?php if ($key == 'userpage' || $key == 'mytalk' || $key == 'mycontris') continue; ?>
 								<li><a href="<?php echo $tool['href']; ?>" class="<?php echo $key; ?>"><?php echo $tool['text']; ?></a></li>
 							<?php endforeach; ?>
-							<?php $specials = $this->getToolbox(); ?>
+							<?php $specials = $this->get('sidebar')['TOOLBOX']; ?>
 							<li><a href="<?php echo $specials['specialpages']['href']; ?>">Admin</a></li>
 						</ul>
 					</div>

--- a/skin.json
+++ b/skin.json
@@ -7,6 +7,7 @@
     "type": "skin",
     "license-name": "BSD-3-Clause",
     "version": "1.1",
+    "manifest_version": 2,
     "ValidSkinNames": {
         "statsforsharks": "StatsForSharks"
     },


### PR DESCRIPTION
These functions are deprecated in MediaWiki 1.36 and later.
When and if you want this skin to continue working these
updates will be required.